### PR TITLE
ci: add devenv test workflow and annotate biome kebab-case rule

### DIFF
--- a/.github/workflows/devenv.yml
+++ b/.github/workflows/devenv.yml
@@ -17,5 +17,7 @@ jobs:
           name: devenv
       - name: Install devenv
         run: nix profile install nixpkgs#devenv
+      - name: Install dependencies
+        run: devenv shell -- bun install --frozen-lockfile
       - name: Run devenv test
         run: devenv test

--- a/.github/workflows/devenv.yml
+++ b/.github/workflows/devenv.yml
@@ -1,0 +1,21 @@
+name: devenv
+
+on:
+  push: {}
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: cachix/install-nix-action@v31
+      - uses: cachix/cachix-action@v16
+        with:
+          name: devenv
+      - name: Install devenv
+        run: nix profile install nixpkgs#devenv
+      - name: Run devenv test
+        run: devenv test

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@macalinao/style-guide",

--- a/devenv.lock
+++ b/devenv.lock
@@ -17,10 +17,10 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1772143911,
+        "lastModified": 1772320113,
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "83c4b5682b84fe04c049970792f38d5879d3c0f1",
+        "rev": "65c59037d2dba83876ec9da8d22584d604553f16",
         "type": "github"
       },
       "original": {
@@ -110,10 +110,10 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1772073411,
+        "lastModified": 1772322520,
         "owner": "lintel-rs",
         "repo": "lintel",
-        "rev": "19b26132dc1eb078fca91662ad3fc220bacc30b9",
+        "rev": "f7fb005931625998e67b9cafcf9d587c42d27935",
         "type": "github"
       },
       "original": {
@@ -124,10 +124,10 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1772082373,
+        "lastModified": 1772173633,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "26eaeac4e409d7b5a6bf6f90a2a2dc223c78d915",
+        "rev": "c0f3d81a7ddbc2b1332be0d8481a672b4f6004d6",
         "type": "github"
       },
       "original": {

--- a/packages/biome-config/base.jsonc
+++ b/packages/biome-config/base.jsonc
@@ -118,6 +118,7 @@
         "useUnifiedTypeSignatures": "error",
         "useExplicitLengthCheck": "error",
         "noDoneCallback": "error",
+        // kebab-case prevents bugs on case-insensitive file systems (macOS, Windows)
         "useFilenamingConvention": {
           "level": "warn",
           "options": {


### PR DESCRIPTION
## Summary
- Add a GitHub Actions workflow (`devenv.yml`) that runs `devenv test` on both Ubuntu and macOS to validate the dev shell and git hooks in CI
- Add a comment to the biome config explaining that `useFilenamingConvention` enforces kebab-case to prevent bugs on case-insensitive file systems (macOS, Windows)
- Remove redundant comment from tsconfig (moved to biome config)

## Test plan
- [ ] Verify the `devenv` workflow runs successfully on both Ubuntu and macOS
- [ ] Confirm `devenv test` builds the shell and runs all configured git hooks (biome, nixfmt, lintel)