### PR TITLE
Enable useMaxParams and noUselessCatchBinding biome rules

### DIFF
--- a/.github/workflows/devenv.yml
+++ b/.github/workflows/devenv.yml
@@ -11,13 +11,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
+      - uses: oven-sh/setup-bun@v2
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
       - uses: cachix/install-nix-action@v31
       - uses: cachix/cachix-action@v16
         with:
           name: devenv
       - name: Install devenv
         run: nix profile install nixpkgs#devenv
-      - name: Install dependencies
-        run: devenv shell -- bun install --frozen-lockfile
       - name: Run devenv test
         run: devenv test

--- a/packages/biome-config/base.jsonc
+++ b/packages/biome-config/base.jsonc
@@ -58,9 +58,14 @@
         "useRegexpExec": "error",
       },
       "complexity": {
+        "noUselessCatchBinding": "error",
         "noUselessUndefined": "error",
         "useSimplifiedLogicExpression": "error",
         "noForEach": "error",
+        // Prefer named arguments via objects over many positional parameters.
+        // This improves readability at call sites, makes argument order irrelevant,
+        // and allows adding new parameters without breaking existing callers.
+        "useMaxParams": "warn",
         "noExcessiveCognitiveComplexity": {
           "level": "error",
           "options": {


### PR DESCRIPTION
## Summary
- Enable `useMaxParams` as a warning to encourage using named arguments via objects instead of many positional parameters. This improves readability, makes argument order irrelevant, and allows adding new parameters without breaking existing callers.
- Enable `noUselessCatchBinding` as an error to enforce ES2019 optional catch binding syntax — unused catch bindings should be omitted entirely.

## Test plan
- [ ] Run `bun run lint` on a consuming project to verify no unexpected breakage