### PR TITLE
chore: require Node 24

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -56,6 +56,7 @@
             ++ (with pkgs; [
               nixfmt
               git
+              nodejs_24
               bun
               turbo
               oxlint

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "typescript": "5.9.3"
   },
   "engines": {
-    "node": ">=22",
+    "node": ">=24",
     "bun": ">=1.0.0"
   },
   "packageManager": "bun@1.3.13"


### PR DESCRIPTION
## Summary
- Bump `engines.node` from `>=22` to `>=24` in the root `package.json`
- Add `nodejs_24` to the nix devShell so the dev environment is explicitly on Node 24 (previously only `bun` was provided)

## Verification
- `nix develop --command node --version` → `v24.16.0`
- Pre-commit hooks (biome / lintel / nixfmt) pass

## Summary by Sourcery

Raise the minimum supported Node.js version to 24 and align the Nix development environment with this requirement.

Build:
- Update the package engine constraint to require Node.js >= 24.
- Add Node.js 24 to the Nix devShell to standardize the local development runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the supported Node.js version to 24 or later.
  * Updated the development environment to use Node.js 24.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->