### PR TITLE
feat: publish via npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,19 +13,19 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # Full history so Changesets can generate changelogs
           fetch-depth: 0
       - name: Cache turbo build setup
-        uses: actions/cache@v5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .turbo
           key: ${{ runner.os }}-turbo-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-turbo-
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
@@ -33,7 +33,7 @@ jobs:
       # older npm, so upgrade it explicitly.
       - name: Upgrade npm for OIDC trusted publishing
         run: npm install -g npm@latest
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
       - name: Install dependencies
         run: bun install --frozen-lockfile
       - name: Build
@@ -42,7 +42,7 @@ jobs:
         run: bun run lint
 
       - name: Create and publish versions
-        uses: changesets/action@v1
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           version: bun run ci:version
           commit: "chore: update versions"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,17 @@ on:
 jobs:
   version:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      # Required for npm OIDC trusted publishing (provenance attestations)
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          # Full history so Changesets can generate changelogs
+          fetch-depth: 0
       - name: Cache turbo build setup
         uses: actions/cache@v5
         with:
@@ -16,9 +24,16 @@ jobs:
           key: ${{ runner.os }}-turbo-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-turbo-
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+      # npm OIDC trusted publishing requires npm >= 11.5.1; Node 22 ships an
+      # older npm, so upgrade it explicitly.
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@latest
       - uses: oven-sh/setup-bun@v2
-      - name: Setup npmrc
-        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
       - name: Install dependencies
         run: bun install --frozen-lockfile
       - name: Build

--- a/flake.nix
+++ b/flake.nix
@@ -57,6 +57,7 @@
               nixfmt
               git
               bun
+              nodejs
               turbo
               oxlint
               oxfmt

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "format": "biome format --write",
     "format:check": "biome check --write",
     "ci:version": "changeset version && bun update",
-    "ci:publish": "for dir in packages/*; do (cd \"$dir\" && bun publish || true); done && changeset tag"
+    "ci:publish": "./scripts/ci-publish.sh"
   },
   "workspaces": {
     "packages": [

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "@macalinao/style-guide",
   "description": "Monorepo containing ESLint and TypeScript configurations.",
   "private": true,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/macalinao/style-guide.git"
+  },
   "version": "0.1.0",
   "scripts": {
     "build": "turbo run build",

--- a/packages/biome-config/package.json
+++ b/packages/biome-config/package.json
@@ -5,7 +5,11 @@
   "version": "0.2.0",
   "type": "module",
   "sideEffects": false,
-  "repository": "github:macalinao/style-guide",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/macalinao/style-guide.git",
+    "directory": "packages/biome-config"
+  },
   "homepage": "https://github.com/macalinao/style-guide",
   "bugs": {
     "url": "https://github.com/macalinao/style-guide/issues"

--- a/packages/eslint-config-react/package.json
+++ b/packages/eslint-config-react/package.json
@@ -5,7 +5,11 @@
   "version": "6.1.0",
   "type": "module",
   "sideEffects": false,
-  "repository": "github:macalinao/style-guide",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/macalinao/style-guide.git",
+    "directory": "packages/eslint-config-react"
+  },
   "homepage": "https://github.com/macalinao/style-guide",
   "bugs": {
     "url": "https://github.com/macalinao/style-guide/issues"

--- a/packages/eslint-config-vite/package.json
+++ b/packages/eslint-config-vite/package.json
@@ -5,7 +5,11 @@
   "version": "2.1.0",
   "type": "module",
   "sideEffects": false,
-  "repository": "github:macalinao/style-guide",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/macalinao/style-guide.git",
+    "directory": "packages/eslint-config-vite"
+  },
   "homepage": "https://github.com/macalinao/style-guide",
   "bugs": {
     "url": "https://github.com/macalinao/style-guide/issues"

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -5,7 +5,11 @@
   "version": "8.1.0",
   "type": "module",
   "sideEffects": false,
-  "repository": "github:macalinao/style-guide",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/macalinao/style-guide.git",
+    "directory": "packages/eslint-config"
+  },
   "homepage": "https://github.com/macalinao/style-guide",
   "bugs": {
     "url": "https://github.com/macalinao/style-guide/issues"

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -5,7 +5,11 @@
   "version": "3.2.5",
   "type": "module",
   "sideEffects": false,
-  "repository": "github:macalinao/style-guide",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/macalinao/style-guide.git",
+    "directory": "packages/tsconfig"
+  },
   "homepage": "https://github.com/macalinao/style-guide",
   "bugs": {
     "url": "https://github.com/macalinao/style-guide/issues"

--- a/scripts/ci-publish.sh
+++ b/scripts/ci-publish.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -e
 
+# nullglob so an unmatched packages/* or *.tgz glob expands to nothing rather
+# than the literal pattern -- otherwise "no tarballs to publish" would be misread
+# as a single bogus tarball named "*.tgz" and fail the run.
+shopt -s nullglob
+
 # Publishing uses npm OIDC trusted publishing (no NPM_TOKEN required).
 #
 # bun publish does not support OIDC trusted publishing yet
@@ -26,7 +31,9 @@ PACK_DIR="$(mktemp -d)"
 echo "Packing publishable packages..."
 for dir in packages/*; do
   if [ -d "$dir" ] && [ -f "$dir/package.json" ]; then
-    if ! grep -q '"private": true' "$dir/package.json"; then
+    # Parse the manifest as JSON rather than grepping for a literal string, so a
+    # private package is skipped regardless of whitespace/key ordering.
+    if ! node -e 'process.exit(JSON.parse(require("node:fs").readFileSync(process.argv[1], "utf8")).private === true ? 0 : 1)' "$dir/package.json"; then
       echo "Packing $(basename "$dir")..."
       # bun pm pack resolves catalog:/workspace: protocols to concrete versions
       (cd "$dir" && bun pm pack --destination "$PACK_DIR")

--- a/scripts/ci-publish.sh
+++ b/scripts/ci-publish.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -e
+
+# Publishing uses npm OIDC trusted publishing (no NPM_TOKEN required).
+#
+# bun publish does not support OIDC trusted publishing yet
+# (https://github.com/oven-sh/bun/issues/22423), so we pack each package with
+# `bun pm pack` -- which rewrites the `catalog:` and `workspace:` protocols to
+# concrete versions in the tarball -- and then publish the resulting tarball
+# with `npm publish`, which supports OIDC and auto-generates provenance.
+#
+# Requires: npm >= 11.5.1 and `id-token: write` permission in the workflow, plus
+# a trusted publisher configured for each package on npmjs.com.
+#
+# Every package is packed and published on every run, not just the ones changesets
+# bumped. That is deliberate: a package whose version is already on the registry
+# is simply skipped, so a release that failed to publish half way through is
+# retried and healed by the next run. It does mean "already published" is the
+# normal outcome for most packages, which is why the errors below are classified
+# rather than ignored.
+
+echo "Publishing packages via npm OIDC trusted publishing..."
+
+PACK_DIR="$(mktemp -d)"
+
+echo "Packing publishable packages..."
+for dir in packages/*; do
+  if [ -d "$dir" ] && [ -f "$dir/package.json" ]; then
+    if ! grep -q '"private": true' "$dir/package.json"; then
+      echo "Packing $(basename "$dir")..."
+      # bun pm pack resolves catalog:/workspace: protocols to concrete versions
+      (cd "$dir" && bun pm pack --destination "$PACK_DIR")
+    fi
+  fi
+done
+
+echo "Publishing tarballs to npm..."
+
+published=()
+skipped=()
+failed=()
+
+for tarball in "$PACK_DIR"/*.tgz; do
+  name="$(basename "$tarball")"
+  echo "Publishing $name..."
+
+  # A non-zero exit is expected for any package changesets did not bump this run,
+  # so the output is captured and classified instead of being discarded. Only an
+  # "already published" error is benign; anything else is a real failure.
+  if output="$(npm publish "$tarball" --access public 2>&1)"; then
+    echo "$output"
+    published+=("$name")
+  elif grep -qF "cannot publish over the previously published versions" <<<"$output"; then
+    echo "  already on the registry, nothing to do"
+    skipped+=("$name")
+  else
+    echo "$output"
+    failed+=("$name")
+  fi
+done
+
+echo
+echo "published: ${#published[@]}, already up to date: ${#skipped[@]}, failed: ${#failed[@]}"
+for name in "${published[@]}"; do echo "  published  $name"; done
+for name in "${failed[@]}"; do echo "  FAILED     $name"; done
+
+if [ "${#failed[@]}" -gt 0 ]; then
+  cat >&2 <<'EOF'
+
+One or more packages failed to publish.
+
+A 404 from the registry means the OIDC identity was not authorized to publish
+that package. The two usual causes:
+
+  - the package has no trusted publisher configured on npmjs.com, or
+  - the package has never been published at all. OIDC cannot publish a package's
+    first version -- npm requires the package to already exist before a trusted
+    publisher can be attached to it (https://github.com/npm/cli/issues/8544).
+    Publish the first version manually, then configure the trusted publisher.
+EOF
+  exit 1
+fi
+
+# Only tag once every package is actually on the registry, so tags never claim a
+# release that did not happen. A failed run is retried in full by the next one.
+echo "Creating git tags..."
+changeset tag
+
+echo "Publishing complete!"


### PR DESCRIPTION
Sets up npm [trusted publishing (OIDC)](https://docs.npmjs.com/trusted-publishers) so packages publish from CI without a long-lived `NPM_TOKEN`, following the pattern from [`macalinao/grill`](https://github.com/macalinao/grill).

## What changed

- **`scripts/ci-publish.sh`** — `bun publish` [doesn't support OIDC yet](https://github.com/oven-sh/bun/issues/22423), so we `bun pm pack` each package (which rewrites `catalog:`/`workspace:` protocols to concrete versions in the tarball) and then `npm publish` the tarball, which supports OIDC and auto-generates provenance. Already-published versions are detected and skipped, so a partially-failed release self-heals on the next run.
- **`.github/workflows/release.yml`** — added `id-token: write` permission, `actions/setup-node` + `npm install -g npm@latest` (OIDC needs npm ≥ 11.5.1; Node 22 ships an older npm), `fetch-depth: 0`, and removed the `NPM_TOKEN` `.npmrc` step.
- **`package.json`** — `ci:publish` now calls `scripts/ci-publish.sh`.
- **`flake.nix`** — added `nodejs` (npm 11.13) to the devShell so `npm` is available locally.

## ⚠️ Required manual step before this can publish

Trusted publishing must be configured **per package** on npmjs.com **before** the workflow runs. For each of the 5 packages (`@macalinao/tsconfig`, `@macalinao/biome-config`, `@macalinao/eslint-config`, `@macalinao/eslint-config-react`, `@macalinao/eslint-config-vite`):

Package → **Settings → Trusted Publisher → GitHub Actions**, with:
- **Organization or user:** `macalinao`
- **Repository:** `style-guide`
- **Workflow filename:** `release.yml`
- **Environment:** (leave blank)

All 5 packages already exist on the registry, so OIDC can attach to them (OIDC can't publish a package's *first* version).

## Summary by Sourcery

Adopt npm OIDC trusted publishing in the release workflow and replace direct bun-based publishing with a script that packs and publishes all workspace packages via npm, ensuring tagging only occurs after successful publication.

New Features:
- Introduce a ci-publish script that packs each publishable workspace package with bun and publishes the resulting tarballs to npm using OIDC trusted publishing, with self-healing behavior for partially failed releases.

Enhancements:
- Update the release GitHub Actions workflow to use Node 22 with an upgraded npm, enable id-token permissions, and configure full git history for changelog generation while removing reliance on an NPM_TOKEN-based .npmrc.
- Expose a dedicated ci:publish npm script that delegates to the new CI publish shell script.
- Add nodejs (with a recent npm) to the Nix dev shell so npm is available for local release operations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the release process to use secure npm trusted publishing (OIDC) instead of writing npm tokens.
  * Improved publishing robustness by handling each eligible package and reporting outcomes as success, skipped (already published), or failed.
  * Publishing now stops and surfaces errors clearly if any package fails, and tags changelogs only after a successful publish run.
  * Release automation uses current Node.js tooling and ensures changelog generation has access to full history.
  * Development environments now include Node.js by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->