### PR TITLE
feat(tsconfig)!: run-anywhere TypeScript flags (major) + document changeset requirement

### DIFF
--- a/.changeset/tsconfig-erasable-syntax-only.md
+++ b/.changeset/tsconfig-erasable-syntax-only.md
@@ -1,5 +1,7 @@
 ---
-"@macalinao/tsconfig": minor
+"@macalinao/tsconfig": major
 ---
 
-Enable `erasableSyntaxOnly` in `tsconfig.base.json` so TypeScript files can be run directly by Node.js via type stripping. This disallows runtime TypeScript-only syntax such as enums, namespaces, and class parameter properties, which may surface new errors in consuming projects.
+Target the modern Node.js + TypeScript world where TypeScript runs anywhere without a build step. Node.js can now execute TypeScript directly via type stripping, and TypeScript has grown flags that guarantee code is compatible with that world. The base config now enables `erasableSyntaxOnly`, `allowImportingTsExtensions`, `rewriteRelativeImportExtensions`, and `moduleDetection: "force"` (alongside the existing `verbatimModuleSyntax`), so source files can be run directly by Node while `tsc` emit rewrites relative `.ts` imports back to `.js` for correct published output. This bans runtime-only TypeScript syntax such as enums, namespaces, and class parameter properties, and requires relative imports to use explicit `.ts` extensions.
+
+Also enables new strictness flags that can surface new errors in consuming projects: `exactOptionalPropertyTypes` (distinguishes `{x?: string}` from `{x: string | undefined}`), `noImplicitReturns`, and `noUncheckedSideEffectImports` (errors on side-effect imports of nonexistent modules).

--- a/.changeset/tsconfig-erasable-syntax-only.md
+++ b/.changeset/tsconfig-erasable-syntax-only.md
@@ -1,0 +1,5 @@
+---
+"@macalinao/tsconfig": minor
+---
+
+Enable `erasableSyntaxOnly` in `tsconfig.base.json` so TypeScript files can be run directly by Node.js via type stripping. This disallows runtime TypeScript-only syntax such as enums, namespaces, and class parameter properties, which may surface new errors in consuming projects.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,20 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `bun run ci:version` - Update package versions using Changesets
 - `bun run ci:publish` - Publish packages to npm
 
+### Changesets
+
+Every PR that changes a published package must include a changeset. Create one with `bun changeset`, or hand-write a markdown file in `.changeset/` with a descriptive kebab-case filename:
+
+```markdown
+---
+"@macalinao/package-name": patch | minor | major
+---
+
+Description of the change from the consumer's perspective.
+```
+
+List every affected package with its semver bump (patch for fixes, minor for new features or behavior changes, major for breaking changes).
+
 ## Architecture Overview
 
 This is a monorepo containing Ian Macalinao's standardized TypeScript and ESLint configurations:

--- a/packages/tsconfig/tsconfig.base.json
+++ b/packages/tsconfig/tsconfig.base.json
@@ -25,6 +25,15 @@
     // this will allow Node to run things directly
     "erasableSyntaxOnly": true,
 
+    // Node's type stripping requires relative imports to use real .ts extensions;
+    // rewriteRelativeImportExtensions (TS 5.7+) rewrites them back to .js on tsc
+    // emit so published output stays correct.
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
+
+    // treat every file as a module
+    "moduleDetection": "force",
+
     // Enable this per-project as it prevents isolatedDeclarations from being used
     // "allowJs": true,
     // "checkJs": true,
@@ -39,7 +48,12 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitOverride": true,
+    "noImplicitReturns": true,
     "noUncheckedIndexedAccess": true,
+    // errors on side-effect imports of nonexistent modules
+    "noUncheckedSideEffectImports": true,
+    // distinguishes {x?: string} from {x: string | undefined}
+    "exactOptionalPropertyTypes": true,
     "noFallthroughCasesInSwitch": true,
     "forceConsistentCasingInFileNames": true,
     // "noErrorTruncation": true,

--- a/packages/tsconfig/tsconfig.base.json
+++ b/packages/tsconfig/tsconfig.base.json
@@ -22,6 +22,9 @@
     // speeds up compilation, make sure you are linting for type-only imports!
     "verbatimModuleSyntax": true,
 
+    // this will allow Node to run things directly
+    "erasableSyntaxOnly": true,
+
     // Enable this per-project as it prevents isolatedDeclarations from being used
     // "allowJs": true,
     // "checkJs": true,


### PR DESCRIPTION
## Summary

- **`@macalinao/tsconfig` (major)**: update `tsconfig.base.json` for the modern Node.js + TypeScript world where TypeScript runs anywhere without a build step:
  - `"erasableSyntaxOnly": true` — allows Node to run TypeScript directly via type stripping; bans runtime-only TS syntax (enums, namespaces, class parameter properties).
  - `"allowImportingTsExtensions": true` + `"rewriteRelativeImportExtensions": true` (TS 5.7+) — Node's type stripping requires relative imports to use real `.ts` extensions; tsc emit rewrites them back to `.js` so published output stays correct.
  - `"moduleDetection": "force"` — treats every file as a module.
  - New strictness flags: `"exactOptionalPropertyTypes"` (distinguishes `{x?: string}` from `{x: string | undefined}`), `"noImplicitReturns"`, `"noUncheckedSideEffectImports"` (errors on side-effect imports of nonexistent modules).

  Shipped as a **major** bump since these flags can surface new errors in consuming projects.

- **CLAUDE.md**: add a Changesets section requiring every PR that touches a published package to include a changeset (`bun changeset` or a hand-written `.changeset/*.md`), with the expected file format and semver guidance.
- Changeset included: `.changeset/tsconfig-erasable-syntax-only.md` (`@macalinao/tsconfig`: major).

## Verification

- `bun run clean && bun run build` passes with all new flags enabled — no package sources needed fixes.
- `bun run format:check` (Biome) passes.

Note: `bun.lock` on master is slightly stale vs `package.json` (`@changesets/cli`, `prettier` ranges); left untouched here as it's unrelated.

## Summary by Sourcery

Update the shared TypeScript base configuration for modern Node.js execution and document the requirement to include Changesets for published package changes.

New Features:
- Configure the tsconfig base to support direct Node.js execution of TypeScript sources with erasable syntax and extension-aware imports.

Enhancements:
- Tighten TypeScript strictness in the shared tsconfig, enabling additional error-detecting compiler flags that may surface new issues in consuming projects.

Documentation:
- Add guidance in CLAUDE.md requiring a Changeset for any PR touching a published package, including example format and semver bump rules.

Chores:
- Add a Changeset entry declaring a major version bump for @macalinao/tsconfig reflecting the new compiler behavior and strictness.