### PR TITLE
ci(dependabot): ignore nix-pinned tool versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,14 @@ updates:
       day: "monday"
       time: "03:00"
     open-pull-requests-limit: 10
+    ignore:
+      # These tools are pinned to the versions nixpkgs provides (see the
+      # update-nixpkgs flow); bump them by updating the nix flake, not here.
+      - dependency-name: "@biomejs/biome"
+      - dependency-name: "turbo"
+      - dependency-name: "typescript"
+      # Kept in lockstep with the nix-pinned turbo version.
+      - dependency-name: "eslint-config-turbo"
     groups:
       # Group all non-major updates together
       minor-and-patch:


### PR DESCRIPTION
Dependabot keeps proposing bumps for tools whose versions are pinned to what nixpkgs provides (`@biomejs/biome`, `turbo`, `typescript` — synced via the update-nixpkgs flow), most recently #328 and #331 which were closed as unappliable after the workspace-catalog migration.

Ignore those packages in the npm ecosystem so the noise stops; version bumps for them happen by updating the nix flake instead. `eslint-config-turbo` is also ignored since it is kept in lockstep with the pinned turbo version.

No changeset: no published package is affected.

## Summary by Sourcery

CI:
- Update Dependabot configuration to ignore @biomejs/biome, turbo, typescript, and eslint-config-turbo in the npm ecosystem.