### PR TITLE
chore: require a 7-day minimum release age for installs

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,2 +1,6 @@
 [install]
 linker = "hoisted"
+
+# Only install package versions published at least 7 days ago, so that
+# malicious releases that get caught and yanked quickly are never pulled in.
+minimumReleaseAge = 604800


### PR DESCRIPTION
Adds `minimumReleaseAge` to the existing `[install]` section of the root `bunfig.toml`:

```toml
[install]
linker = "hoisted"

minimumReleaseAge = 604800
```

## What this does

`install.minimumReleaseAge` tells Bun to filter out npm package versions published more recently than the given threshold. The value is **in seconds**, so `604800` = 7 days. During `bun install`, Bun resolves to the newest version that is at least 7 days old and ignores anything published inside that window.

## Why

This is a supply-chain mitigation. When an npm package is compromised — a maintainer account is phished, a publish token leaks, a postinstall script is backdoored — the malicious version is typically detected, reported, and yanked from the registry within hours to a few days. The damage lands on whoever installed during that short window.

Holding installs back by a week means those releases are almost always pulled from the registry before they are ever eligible for our lockfile. It costs us a 7-day delay on picking up new versions and buys immunity to the fast-yanked class of attack.

## Notes

- `minimumReleaseAgeExcludes` is available if we ever need to exempt a specific package from the age gate. Not used here — nothing currently needs to bypass it.
- Version ranges already pinned in `bun.lock` are unaffected; this only governs what new resolutions are allowed to pick up.
- No changeset: this is a repo-root config file and no published package changed.

## Summary by Sourcery

Chores:
- Add minimumReleaseAge to the root bunfig.toml install configuration to enforce a 7-day minimum publication age for newly resolved npm package versions.